### PR TITLE
Support for BioSamples Submissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ dmypy.json
 # Ignore non-blank example Files
 examples/*
 !examples/blank*
+
+# Ignore biosamples-cache
+biosamples-cache.sqlite

--- a/cli.py
+++ b/cli.py
@@ -41,14 +41,17 @@ if __name__ == '__main__':
         issues_file_path = file_name + '_issues.json'
         write_dict(issues_file_path, issues)
         print(f'Issues from {len(issues)} rows written to: {issues_file_path}')
-
+    
     if args['biosamples']:
         if not data:
             print('No Data to Submit to BioSamples')
             sys.exit(2)
 
-        # ToDo: if issues: Ask user if they want to proceed with detected issues.
-        # This may have to wait until we can classify issues into Errors (that will block submission), Warnings and Info
+        if issues:
+            user_text = input('Continue with BioSamples Submission? (y/N):')
+            if not user_text.lower().startswith('y'):
+                print('Exiting')
+                sys.exit(0)
 
         aap_url = args['aap_url']
         url = args['biosamples_url']

--- a/cli.py
+++ b/cli.py
@@ -5,6 +5,7 @@ import sys
 
 from excel.load import get_dict_from_excel
 from excel.validate import validate_dict_from_excel
+from services.biosamples import BioSamples
 
 
 def write_dict(file_path, data_dict):
@@ -64,5 +65,22 @@ if __name__ == '__main__':
             sys.exit(2)
 
         print(f'Attempting to Submit to BioSamples: {biosamples_url}, AAP: {aap_url}')
+        biosamples = BioSamples(biosamples_url, aap_url, aap_username, aap_password)
+        bio_samples = []
+        for row in data:
+            if 'sample' in row:
+                bio_samples.append(biosamples.encode_sample(row['sample']))
+        if bio_samples:
+            biosamples_requests_path = file_name + '_BioSamples_requests.json'
+            write_dict(biosamples_requests_path, bio_samples)
+            print(f'{len(bio_samples)} BioSamples objects written to: {biosamples_requests_path}')
+
+        biosamples_responses = []
+        for sample in bio_samples:
+            biosamples_responses.append(biosamples.send_sample(sample))
+        if biosamples_responses:
+            biosamples_responses_path = file_name + '_BioSamples_responses.json'
+            write_dict(biosamples_responses_path, biosamples_responses)
+            print(f'{len(biosamples_responses)} BioSamples responses written to: {biosamples_responses_path}')
 
     sys.exit(0)

--- a/cli.py
+++ b/cli.py
@@ -5,7 +5,7 @@ import sys
 
 from excel.load import get_dict_from_excel
 from excel.validate import validate_dict_from_excel
-from services.biosamples import BioSamples
+from services.biosamples import AapClient, BioSamples
 
 
 def write_dict(file_path, data_dict):
@@ -21,7 +21,8 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Parse, Validate and Submit excel files to EBI Resources')
     parser.add_argument('file_path', type=str, help='path of excel file to load')
     parser.add_argument('--biosamples', action='store_true', help='Submit to BioSamples, requires environment variables AAP_USERNAME and AAP_PASSWORD')
-
+    
+    parser.add_argument('--biosamples_domain', type=str, help='Override the BioSamples domain rather than detect the domain from the excel file.')
     parser.add_argument('--biosamples_url', type=str, default='https://www.ebi.ac.uk/biosamples', help='Override the default URL for BioSamples API.')
     parser.add_argument('--aap_url', type=str, default='https://api.aai.ebi.ac.uk', help='Override the default URL for AAP API.')
 
@@ -49,8 +50,9 @@ if __name__ == '__main__':
         # ToDo: if issues: Ask user if they want to proceed with detected issues.
         # This may have to wait until we can classify issues into Errors (that will block submission), Warnings and Info
 
-        biosamples_url = args['biosamples_url']
         aap_url = args['aap_url']
+        url = args['biosamples_url']
+        domain = args['biosamples_domain']
 
         if 'AAP_USERNAME' in os.environ:
             aap_username = os.environ['AAP_USERNAME']
@@ -64,8 +66,9 @@ if __name__ == '__main__':
             print('No AAP_PASSWORD detected in os environment variables.')
             sys.exit(2)
 
-        print(f'Attempting to Submit to BioSamples: {biosamples_url}, AAP: {aap_url}')
-        biosamples = BioSamples(biosamples_url, aap_url, aap_username, aap_password)
+        print(f'Attempting to Submit to BioSamples: {url}, AAP: {aap_url}')
+        aap_client = AapClient(url=aap_url, username=aap_username, password=aap_password)
+        biosamples = BioSamples(aap_client, url, domain)
         bio_samples = []
         for row in data:
             if 'sample' in row:

--- a/cli.py
+++ b/cli.py
@@ -15,8 +15,13 @@ def write_dict(file_path, data_dict):
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='')
+    parser = argparse.ArgumentParser(description='Parse, Validate and Submit excel files to EBI Resources')
     parser.add_argument('file_path', type=str, help='path of excel file to load')
+    parser.add_argument('--biosamples', action='store_true', help='Submit to BioSamples, requires environment variables AAP_USERNAME and AAP_PASSWORD')
+    
+    parser.add_argument('--biosamples_url', type=str, default='https://www.ebi.ac.uk/biosamples', help='Overridde the default URL for BioSamples API.')
+    parser.add_argument('--aap_url', type=str, default='https://api.aai.ebi.ac.uk', help='Overridde the default URL for AAP API.')
+    
     args = vars(parser.parse_args())
     excel_file_path = args['file_path']
 
@@ -26,7 +31,36 @@ if __name__ == '__main__':
     if data:
         json_file_path = os.path.splitext(excel_file_path)[0] + '.json'
         write_dict(json_file_path, data)
+        print(f'Data written to: {json_file_path}')
 
     if issues:
         issues_file_path = os.path.splitext(excel_file_path)[0] + '_issues.json'
         write_dict(issues_file_path, issues)
+        print(f'Issues written to: {issues_file_path}')
+
+    if args['biosamples']:
+        if not data:
+            print ('No Data to Submit to BioSamples')
+            exit(2)
+
+        # ToDo: if issues: Ask user if they want to proceed with detected issues.
+        # This may have to wait until we can classify issues into Errors (that will block submission), Warnings and Info
+
+        biosamples_url = args['biosamples_url']
+        aap_url = args['aap_url']
+        
+        if 'AAP_USERNAME' in os.environ:
+            aap_username = os.environ['AAP_USERNAME']
+        else:
+            print('No AAP_USERNAME detected in os environment variables.')
+            exit(2)
+        
+        if 'AAP_PASSWORD' in os.environ:
+            aap_password = os.environ['AAP_PASSWORD']
+        else:
+            print('No AAP_PASSWORD detected in os environment variables.')
+            exit(2)
+        
+        print(f'Attempting to Submit to BioSamples: {biosamples_url}, AAP: {aap_url}')
+    
+    exit(0)

--- a/cli.py
+++ b/cli.py
@@ -1,6 +1,8 @@
 import argparse
 import json
 import os
+import sys
+
 from excel.load import get_dict_from_excel
 from excel.validate import validate_dict_from_excel
 
@@ -18,10 +20,10 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Parse, Validate and Submit excel files to EBI Resources')
     parser.add_argument('file_path', type=str, help='path of excel file to load')
     parser.add_argument('--biosamples', action='store_true', help='Submit to BioSamples, requires environment variables AAP_USERNAME and AAP_PASSWORD')
-    
-    parser.add_argument('--biosamples_url', type=str, default='https://www.ebi.ac.uk/biosamples', help='Overridde the default URL for BioSamples API.')
-    parser.add_argument('--aap_url', type=str, default='https://api.aai.ebi.ac.uk', help='Overridde the default URL for AAP API.')
-    
+
+    parser.add_argument('--biosamples_url', type=str, default='https://www.ebi.ac.uk/biosamples', help='Override the default URL for BioSamples API.')
+    parser.add_argument('--aap_url', type=str, default='https://api.aai.ebi.ac.uk', help='Override the default URL for AAP API.')
+
     args = vars(parser.parse_args())
     excel_file_path = args['file_path']
 
@@ -40,27 +42,27 @@ if __name__ == '__main__':
 
     if args['biosamples']:
         if not data:
-            print ('No Data to Submit to BioSamples')
-            exit(2)
+            print('No Data to Submit to BioSamples')
+            sys.exit(2)
 
         # ToDo: if issues: Ask user if they want to proceed with detected issues.
         # This may have to wait until we can classify issues into Errors (that will block submission), Warnings and Info
 
         biosamples_url = args['biosamples_url']
         aap_url = args['aap_url']
-        
+
         if 'AAP_USERNAME' in os.environ:
             aap_username = os.environ['AAP_USERNAME']
         else:
             print('No AAP_USERNAME detected in os environment variables.')
-            exit(2)
-        
+            sys.exit(2)
+
         if 'AAP_PASSWORD' in os.environ:
             aap_password = os.environ['AAP_PASSWORD']
         else:
             print('No AAP_PASSWORD detected in os environment variables.')
-            exit(2)
-        
+            sys.exit(2)
+
         print(f'Attempting to Submit to BioSamples: {biosamples_url}, AAP: {aap_url}')
-    
-    exit(0)
+
+    sys.exit(0)

--- a/cli.py
+++ b/cli.py
@@ -26,19 +26,19 @@ if __name__ == '__main__':
 
     args = vars(parser.parse_args())
     excel_file_path = args['file_path']
+    file_name = os.path.splitext(excel_file_path)[0]
 
     data = get_dict_from_excel(excel_file_path)
-    issues = validate_dict_from_excel(excel_file_path, data)
-
     if data:
-        json_file_path = os.path.splitext(excel_file_path)[0] + '.json'
+        json_file_path = file_name + '.json'
         write_dict(json_file_path, data)
-        print(f'Data written to: {json_file_path}')
+        print(f'Data from {len(data)} rows written to: {json_file_path}')
 
+    issues = validate_dict_from_excel(excel_file_path, data)
     if issues:
-        issues_file_path = os.path.splitext(excel_file_path)[0] + '_issues.json'
+        issues_file_path = file_name + '_issues.json'
         write_dict(issues_file_path, issues)
-        print(f'Issues written to: {issues_file_path}')
+        print(f'Issues from {len(issues)} rows written to: {issues_file_path}')
 
     if args['biosamples']:
         if not data:

--- a/cli.py
+++ b/cli.py
@@ -48,7 +48,7 @@ if __name__ == '__main__':
             sys.exit(2)
 
         if issues:
-            user_text = input('Continue with BioSamples Submission? (y/N):')
+            user_text = input('Continue with BioSamples Submission? (y/N)?:')
             if not user_text.lower().startswith('y'):
                 print('Exiting')
                 sys.exit(0)

--- a/excel/clean.py
+++ b/excel/clean.py
@@ -1,3 +1,4 @@
+from datetime import date
 from typing import List
 
 def clean_object(name: str) -> str:
@@ -30,3 +31,15 @@ def clean_validation_list(validation_list: List[str]) -> List[str]:
 def clean_validation(value: str) -> str:
     # Validation is case-insensitive
     return value.lower()
+
+
+def object_has_attribute(object_data: dict, attribute: str) -> bool:
+    return attribute in object_data and object_data[attribute].strip() not in ['NP', 'NA', 'NC']
+
+
+def valid_date(value: str) -> bool:
+    try:
+        date.fromisoformat(value)
+        return True
+    except Exception:
+        return False

--- a/excel/clean.py
+++ b/excel/clean.py
@@ -1,6 +1,7 @@
 from datetime import date
 from typing import List
 
+
 def clean_object(name: str) -> str:
     # Objects may include a postfix which can be discarded
     return clean_name(name.partition('-')[0])
@@ -34,12 +35,16 @@ def clean_validation(value: str) -> str:
 
 
 def object_has_attribute(object_data: dict, attribute: str) -> bool:
-    return attribute in object_data and object_data[attribute].strip() not in ['NP', 'NA', 'NC']
+    return attribute in object_data and value_populated(object_data[attribute].strip())
+
+
+def value_populated(value: str) -> bool:
+    return value not in ['NP', 'NA', 'NC']
 
 
 def valid_date(value: str) -> bool:
     try:
         date.fromisoformat(value)
         return True
-    except Exception:
+    except (TypeError, ValueError):
         return False

--- a/excel/load.py
+++ b/excel/load.py
@@ -1,5 +1,5 @@
 from openpyxl import load_workbook
-from excel.clean import clean_object, clean_name
+from .clean import clean_object, clean_name
 
 
 def get_column_map(worksheet) -> dict:

--- a/excel/validate.py
+++ b/excel/validate.py
@@ -1,20 +1,7 @@
-from datetime import date
 from openpyxl import load_workbook
 from openpyxl.worksheet.datavalidation import DataValidationList
 from openpyxl.worksheet.worksheet import Worksheet
-from excel.clean import *
-
-
-def valid_date(value: str) -> bool:
-    try:
-        fromiso = date.fromisoformat(value)
-        return True
-    except Exception:
-        return False
-
-
-def object_has_attribute(object_data: dict, attribute: str) -> bool:
-    return attribute in object_data and object_data[attribute].strip() not in ['NP', 'NA', 'NC']
+from excel.clean import object_has_attribute, clean_validation, clean_object, clean_key, clean_name, clean_formula_list, clean_validation_list, valid_date
 
 
 def object_has_accession(object_data: dict):

--- a/excel/validate.py
+++ b/excel/validate.py
@@ -1,7 +1,7 @@
 from openpyxl import load_workbook
 from openpyxl.worksheet.datavalidation import DataValidationList
 from openpyxl.worksheet.worksheet import Worksheet
-from excel.clean import object_has_attribute, clean_validation, clean_object, clean_key, clean_name, clean_formula_list, clean_validation_list, valid_date
+from .clean import object_has_attribute, clean_validation, clean_object, clean_key, clean_name, clean_formula_list, clean_validation_list, valid_date
 
 
 def object_has_accession(object_data: dict):

--- a/excel/validate.py
+++ b/excel/validate.py
@@ -52,6 +52,7 @@ def validate_data_row(validation_map: dict, data_row):
 
 
 def validate_data_list(validation_map: dict, data):
+    # ToDo: Return validation report as a dictionary of row_index: List[row_errors]
     validation_report = []
     for item in data:
         row_errors = validate_data_row(validation_map, item)

--- a/excel/validate.py
+++ b/excel/validate.py
@@ -1,7 +1,8 @@
 from openpyxl import load_workbook
 from openpyxl.worksheet.datavalidation import DataValidationList
 from openpyxl.worksheet.worksheet import Worksheet
-from .clean import object_has_attribute, clean_validation, clean_object, clean_key, clean_name, clean_formula_list, clean_validation_list, valid_date
+from .clean import (object_has_attribute, clean_validation, clean_object, clean_key, clean_name, clean_formula_list,
+                    clean_validation_list, valid_date)
 
 
 def object_has_accession(object_data: dict):
@@ -15,17 +16,20 @@ def validate_object(object_validation: dict, object_data: dict):
             if 'mandatory' in attribute_info and not object_has_accession(object_data):
                 mandatory = attribute_info['mandatory'].strip()
                 if mandatory == 'M':
-                    errors.append('Error: Mandatory Atrribute {} is missing.'.format(attribute_name))
+                    errors.append(f'Error: Mandatory Attribute {attribute_name} is missing.')
                 elif mandatory == 'R':
-                    errors.append('Warning: Reccomended Atrribute {} is missing.'.format(attribute_name))
+                    errors.append(f'Warning: Recommended Attribute {attribute_name} is missing.')
                 elif mandatory != 'O':
-                    errors.append('Info: Atrribute {} may be required. {}'.format(attribute_name, mandatory))
+                    errors.append(f'Info: Attribute {attribute_name} may be required. {mandatory}')
         else:
             value = object_data[attribute_name]
             if 'format' in attribute_info and attribute_info['format'] == 'YYYY-MM-DD' and not valid_date(value):
-                errors.append('Error: {} has value {}, which is not in date format YYYY-MM-DD.'.format(attribute_name, value))
+                errors.append(f'Error: {attribute_name} has value {value}, which is not in date format YYYY-MM-DD.')
             if 'accepted_values' in attribute_info and clean_validation(value) not in attribute_info['accepted_values']:
-                errors.append('Error: {} has value {} which is not in list of accepted values. {}'.format(attribute_name, value, attribute_info['accepted_values']))
+                accepted = attribute_info['accepted_values']
+                errors.append(
+                    f'Error: {attribute_name} has value {value}, which is not in list of accepted values. {accepted}'
+                )
     if errors:
         object_data['errors'] = errors
     return errors
@@ -52,13 +56,13 @@ def validate_data_list(validation_map: dict, data):
     for item in data:
         row_errors = validate_data_row(validation_map, item)
         if row_errors:
-            validation_report.append({ item['row']: row_errors })
+            validation_report.append({item['row']: row_errors})
     return validation_report
 
 
 def get_excel_validations(validations: DataValidationList):
     validation_list = {}
-    # If Excel's data vaidation is used for displaying accepted values on header row,
+    # If Excel's data validation is used for displaying accepted values on header row,
     # Replace single selected value with all accepted values
     for validation in validations:
         if validation.validation_type == 'list':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 openpyxl
+git+https://github.com/ebi-ait/python_biosamples-v4_lib.git@covid-excel-utils#egg=biosamples-v4

--- a/services/biosamples.py
+++ b/services/biosamples.py
@@ -30,15 +30,17 @@ def make_attributes(sample: dict) -> List[Attribute]:
     return attributes
 
 
-def fixup_sample(sample: dict):
+def fixup_sample(sample: dict) -> dict:
+    fixed_sample = sample.copy()
     remove_keys = ['errors', 'schema_erros', 'sample_accession', 'sample_alias', 'sample_title', 'sample_description', 'tax_id',
                    'scientific_name', 'domain']
     for key in remove_keys:
-        if key in sample:
-            sample.pop(key)
+        if key in fixed_sample:
+            fixed_sample.pop(key)
 
-    if 'collecting_institution' not in sample and 'collecting_institute' in sample:
-        sample['collecting_institution'] = sample.pop('collecting_institute')
+    if 'collecting_institution' not in fixed_sample and 'collecting_institute' in fixed_sample:
+        fixed_sample['collecting_institution'] = fixed_sample.pop('collecting_institute')
+    return fixed_sample
 
 
 def map_sample(input_sample: dict) -> Sample:
@@ -50,8 +52,7 @@ def map_sample(input_sample: dict) -> Sample:
         species=optional_attribute(input_sample, 'scientific_name')
     )
     sample._append_organism_attribute()
-    fixup_sample(input_sample)
-    sample.attributes.extend(make_attributes(input_sample))
+    sample.attributes.extend(make_attributes(fixup_sample(input_sample)))
     return sample
 
 

--- a/services/biosamples.py
+++ b/services/biosamples.py
@@ -6,7 +6,11 @@ from biosamples_v4.models import Attribute, Sample
 from excel.clean import object_has_attribute, value_populated
 
 
-def optional_sample_attribute(sample: dict, attribute: str):
+def attribute_name(name: str) -> str:
+    return name.replace('_', ' ')
+
+
+def optional_attribute(sample: dict, attribute: str):
     return sample[attribute] if object_has_attribute(sample, attribute) else None
 
 
@@ -14,25 +18,26 @@ def make_attributes(sample: dict) -> List[Attribute]:
     attributes = []
     for attribute, value in sample.items():
         if value_populated(value):
-            attributes.append(Attribute(name=attribute, value=value))
+            attributes.append(Attribute(name=attribute_name(attribute), value=value))
     return attributes
 
 
 def fixup_sample(sample: dict):
-    remove_keys = ['sample_accession', 'sample_alias', 'sample_title', 'sample_description', 'tax_id', 'scientific_name']
+    remove_keys = ['sample_accession', 'sample_alias', 'sample_title', 'sample_description', 'tax_id',
+                   'scientific_name', 'domain']
     for key in remove_keys:
         if key in sample:
             sample.pop(key)
-    
+
     if 'collecting_institution' not in sample and 'collecting_institute' in sample:
         sample['collecting_institution'] = sample.pop('collecting_institute')
 
 
 def map_sample(input_sample: dict) -> Sample:
-    accession = optional_sample_attribute(input_sample, 'sample_accession')
-    name = optional_sample_attribute(input_sample, 'sample_title')
-    ncbi_taxon_id = optional_sample_attribute(input_sample, 'tax_id')
-    species = optional_sample_attribute(input_sample, 'scientific_name')
+    accession = optional_attribute(input_sample, 'sample_accession')
+    name = optional_attribute(input_sample, 'sample_title')
+    ncbi_taxon_id = optional_attribute(input_sample, 'tax_id')
+    species = optional_attribute(input_sample, 'scientific_name')
     fixup_sample(input_sample)
 
     sample = Sample(
@@ -55,10 +60,12 @@ class BioSamples:
         )
         self.biosamples = BioSamplesClient(biosamples_url)
         self.encoder = SampleEncoder()
-    
+
     def encode_sample(self, input_sample: dict) -> dict:
         sample = map_sample(input_sample)
-        return self.encoder.default(sample)        
+        return self.encoder.default(sample)
 
     def send_sample(self, sample: dict):
+        if 'accession' in sample:
+            return self.biosamples.update_sample(sample=sample, jwt=self.aap.get_token())
         return self.biosamples.persist_sample(sample=sample, jwt=self.aap.get_token())

--- a/services/biosamples.py
+++ b/services/biosamples.py
@@ -1,0 +1,64 @@
+from typing import List
+from biosamples_v4.api import Client as BioSamplesClient
+from biosamples_v4.aap import Client as AapClient
+from biosamples_v4.encoders import SampleEncoder
+from biosamples_v4.models import Attribute, Sample
+from excel.clean import object_has_attribute, value_populated
+
+
+def optional_sample_attribute(sample: dict, attribute: str):
+    return sample[attribute] if object_has_attribute(sample, attribute) else None
+
+
+def make_attributes(sample: dict) -> List[Attribute]:
+    attributes = []
+    for attribute, value in sample.items():
+        if value_populated(value):
+            attributes.append(Attribute(name=attribute, value=value))
+    return attributes
+
+
+def fixup_sample(sample: dict):
+    remove_keys = ['sample_accession', 'sample_alias', 'sample_title', 'sample_description', 'tax_id', 'scientific_name']
+    for key in remove_keys:
+        if key in sample:
+            sample.pop(key)
+    
+    if 'collecting_institution' not in sample and 'collecting_institute' in sample:
+        sample['collecting_institution'] = sample.pop('collecting_institute')
+
+
+def map_sample(input_sample: dict) -> Sample:
+    accession = optional_sample_attribute(input_sample, 'sample_accession')
+    name = optional_sample_attribute(input_sample, 'sample_title')
+    ncbi_taxon_id = optional_sample_attribute(input_sample, 'tax_id')
+    species = optional_sample_attribute(input_sample, 'scientific_name')
+    fixup_sample(input_sample)
+
+    sample = Sample(
+        accession=accession,
+        name=name,
+        ncbi_taxon_id=ncbi_taxon_id,
+        species=species
+    )
+    sample._append_organism_attribute()
+    sample.attributes.extend(make_attributes(input_sample))
+    return sample
+
+
+class BioSamples:
+    def __init__(self, biosamples_url, aap_url, aap_username, aap_password):
+        self.aap = AapClient(
+            url=aap_url,
+            username=aap_username,
+            password=aap_password
+        )
+        self.biosamples = BioSamplesClient(biosamples_url)
+        self.encoder = SampleEncoder()
+    
+    def encode_sample(self, input_sample: dict) -> dict:
+        sample = map_sample(input_sample)
+        return self.encoder.default(sample)        
+
+    def send_sample(self, sample: dict):
+        return self.biosamples.persist_sample(sample=sample, jwt=self.aap.get_token())

--- a/services/biosamples.py
+++ b/services/biosamples.py
@@ -14,17 +14,12 @@ def optional_attribute(sample: dict, attribute: str):
     return sample[attribute] if object_has_attribute(sample, attribute) else None
 
 
-# Only Suitable for COVID uses, will need to externalise to make package suitable for other purposes
 def make_attribute(name, value) -> Attribute:
-    iri = None
     units = None
-    if name in ['host_common_name', 'host_scientific_name'] and value.lower() in ['human', 'homo sapiens']:
-        iri = 'http://purl.obolibrary.org/obo/NCBITaxon_9606'
-    elif name.startswith('isolation') and value.lower() == 'nasopharyngeal swab':
-        iri = 'http://purl.obolibrary.org/obo/NCIT_C155831'
-    elif name == 'geographic_location_(latitude)' or name == 'geographic_location_(longitude)':
+    # ToDo: Refactor to create the Sample at validation-time so the units are accessible from validation_map
+    if name in ['geographic_location_(latitude)', 'geographic_location_(longitude)']:
         units = 'DD'
-    return Attribute(name=attribute_name(name), value=value, iris=iri, unit=units)
+    return Attribute(name=attribute_name(name), value=value, unit=units)
 
 
 def make_attributes(sample: dict) -> List[Attribute]:
@@ -36,7 +31,7 @@ def make_attributes(sample: dict) -> List[Attribute]:
 
 
 def fixup_sample(sample: dict):
-    remove_keys = ['errors', 'sample_accession', 'sample_alias', 'sample_title', 'sample_description', 'tax_id',
+    remove_keys = ['errors', 'schema_erros', 'sample_accession', 'sample_alias', 'sample_title', 'sample_description', 'tax_id',
                    'scientific_name', 'domain']
     for key in remove_keys:
         if key in sample:


### PR DESCRIPTION
- [x] Accept CLI Arguments
- [x] Submit new Sample to BioSamples
- [x] Update Sample when `accession` provided
- [x] Provide `domain` CLI parameter
- [x] Ask for user input before submitting BioSamples that contain issues.
- [x] Bring units from spreadsheet to Sample Attribute (for geographic data)
- [x] ~~Populate 9606 ontology for `host_common_name`, `host_scientific_name`~~
    - Removed as BioSamples will auto curate these overnight.
- [x] Return friendlier error that `traverson` failing when accession is not found.
- [x] Report submission errors into the same objects as normal errors.

Out of Scope:
- Validate against BioSamples (without submitting)
    - Add feature to: [ebi-ait/python_biosamples-v4_lib](https://github.com/ebi-ait/python_biosamples-v4_lib)
- Return Accessions back to Excel (Better)

Dependant upon: [biosamples-v4#6](https://github.com/ebi-ait/python_biosamples-v4_lib/pull/6)
[Populated Test Sample](https://wwwdev.ebi.ac.uk/biosamples/samples/SAMEA5574070)
[Manually Populated Production Sample](https://www.ebi.ac.uk/biosamples/samples/SAMEA7098099), for comparison.