### PR TITLE
BioSample Submissions: JWT Tokens and Error Reporting

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -43,7 +43,7 @@ class CovidExcelUtils:
         aap_client = AapClient(url=aap_url, username=aap_username, password=aap_password)
         biosamples = BioSamples(aap_client, url, domain)
         biosamples_count = 0
-        for row in self.excel.data.values():
+        for row_index, row in self.excel.data.items():
             if 'sample' in row:
                 try:
                     row['sample']['request'] = biosamples.encode_sample(row['sample'])
@@ -51,8 +51,9 @@ class CovidExcelUtils:
                     row['sample'].pop('request')
                     biosamples_count = biosamples_count + 1
                 except Exception as error:
-                    error_msg = f'Encoding Error: {error}'
+                    error_msg = f'BioSamples Error: {error}'
                     row['sample'].setdefault('errors', {}).setdefault('sample_accession', []).append(error_msg)
+                    self.excel.errors.setdefault(row_index, {}).setdefault('sample', {}).setdefault('sample_accession', []).append(error_msg)
         logging.info(f'Successfully submitted {biosamples_count} BioSamples')
 
     def close(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 openpyxl
 requests
 docker
-git+https://github.com/ebi-ait/python_biosamples-v4_lib.git@covid-excel-utils#egg=biosamples-v4
+pyjwt==1.7.1
+git+https://github.com/ebi-ait/python_biosamples-v4_lib.git@covid-excel-utils#egg=biosamples-v4 #  Issue: Does not respect locked versions from biosamples repo requirements.txt


### PR DESCRIPTION
Merging in fixes for the errors found by @mshadbolt's testing of the BioSample submissions functionality.
Let's keep this PR open for a bit to see if Marion finds any other issues, but when relevant we should merge this stuff into our active development in #19.

Current fixes:
- Lock the `pyjwt` version manually to `1.7.1`:
    - Workaround: This **is** locked [in BioSamples library](https://github.com/ebi-ait/python_biosamples-v4_lib/blob/bf39b76803bed233e4ac6122948faf3edce505e1/requirements.txt#L5) but the specific version dependency isn't being honoured when being brought into pip via GitHub
    - We may need to post the library to PyPi for this version dependency  to take effect
- Fix a bug where errors in BioSamples submission weren't being logged as errors
    - They were still being written to the json file.
    - This bit of code is under review in #19 so might not need to be merged in verbatim