### PR TITLE
Change column header to collecting institution

### DIFF
--- a/services/biosamples.py
+++ b/services/biosamples.py
@@ -38,8 +38,6 @@ def fixup_sample(sample: dict) -> dict:
         if key in fixed_sample:
             del fixed_sample[key]
 
-    if 'collecting_institution' not in fixed_sample and 'collecting_institute' in fixed_sample:
-        fixed_sample['collecting_institution'] = fixed_sample.pop('collecting_institute')
     return fixed_sample
 
 

--- a/validation/schema/sample.json
+++ b/validation/schema/sample.json
@@ -20,7 +20,7 @@
     "host_sex",
     "host_scientific_name",
     "collector_name",
-    "collecting_institute",
+    "collecting_institution",
     "isolate"
   ],
   "properties": {
@@ -120,7 +120,7 @@
         ]
       }
     },
-    "collecting_institute": {
+    "collecting_institution": {
       "description": "Name of the institution to which the person collecting the specimen belongs. Format: Institute Name, Institute Address",
       "type": "string"
     },


### PR DESCRIPTION
Change column header from `collecting_institute` to `collecting_institution`.

Related changes:
- Changed column header in the JSON schema
- Removed unnecessary lines from BioSamples service