### PR TITLE
Excel Validation and Accession fixes

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -85,7 +85,7 @@ class CovidExcelUtils:
     def close(self):
         if self.excel:
             if isinstance(self.excel, ExcelMarkup):
-                self.excel.add_biosample_accessions()
+                self.excel.add_accessions()
                 self.excel.markup_with_errors()
                 self.excel.close()
                 logging.info(f'Excel file updated: {self.__file_path}')

--- a/excel/markup.py
+++ b/excel/markup.py
@@ -33,10 +33,8 @@ class ExcelMarkup(ValidatingExcel):
                     self.__sheet[cell_index].comment = self.__get_error_comment(human_errors)
                     self.__sheet[cell_index].fill = error_fill
             if error_count:
-                self.__sheet[f'B{row_index}'] = f'Errors'
-                self.__sheet[f'B{row_index}'].fill = error_fill
-                self.__sheet[f'C{row_index}'] = f'{error_count} Errors'
-                self.__sheet[f'C{row_index}'].fill = error_fill
+                self.__sheet[f'A{row_index}'] = f'{error_count} Errors'
+                self.__sheet[f'A{row_index}'].fill = error_fill
 
     # ToDo: When Submission accession functionality is done, save all 'new' accessions for all types
     def add_biosample_accessions(self):
@@ -66,14 +64,8 @@ class ExcelMarkup(ValidatingExcel):
     def __clear_markup(excel_path, sheet_index):
         with closing(load_workbook(filename=excel_path, keep_links=False)) as book:
             sheet = book.worksheets[sheet_index]
-
-            if sheet['B1'].value == 'validation':
-                sheet.delete_cols(2, 2)
-
-            sheet.insert_cols(2, 2)
-            sheet['B1'] = 'validation'
-            sheet['B2'] = 'summary'
-            sheet['C2'] = 'number_of_errors'
+            sheet.delete_cols(1, 1)
+            sheet.insert_cols(1, 1)
 
             for row in sheet.iter_rows():
                 for cell in row:

--- a/excel/markup.py
+++ b/excel/markup.py
@@ -28,9 +28,8 @@ class ExcelMarkup(ValidatingExcel):
                 for attribute_name, attribute_errors in entity_errors.items():
                     error_count = error_count + len(attribute_errors)
                     human_errors = self.human_attribute_errors(entity_type, attribute_name, attribute_errors)
-                    # ToDo: Report ALL missing mandatory fields rather than just first
                     cell_index = self.lookup_cell_index(entity_type, attribute_name, row_index)
-                    self.__sheet[cell_index].comment = self.__get_error_comment(human_errors)
+                    self.__sheet[cell_index].comment = self.__get_error_comment(human_errors, self.__sheet[cell_index].comment)
                     self.__sheet[cell_index].fill = error_fill
             if error_count:
                 self.__sheet[f'A{row_index}'] = f'{error_count} Errors'
@@ -74,9 +73,13 @@ class ExcelMarkup(ValidatingExcel):
             book.save(excel_path)
 
     @staticmethod
-    def __get_error_comment(human_errors):
-        human_error = '\r\n'.join(human_errors)
-        comment = Comment(human_error, f'Validation')
+    def __get_error_comment(human_errors, existing_comment: Comment = None):
+        stack = []
+        if existing_comment and existing_comment.text:
+            stack.append(existing_comment.text)
+        stack.extend(human_errors)
+        text = '\r\n'.join(stack)
+        comment = Comment(text, f'Validation')
         comment.width = 500
         comment.height = 100
         return comment

--- a/test/unit/excel/test_accession_handling.py
+++ b/test/unit/excel/test_accession_handling.py
@@ -1,0 +1,105 @@
+import unittest
+
+from excel.load import ExcelLoader
+from excel.submission import ExcelSubmission
+
+
+class TestExcelAccessionHandling(unittest.TestCase):
+    def test_adding_mapped_or_default_service_accessions(self):
+        expected_accessions = {
+            'BioStudies': ['PRJEB12345'],
+            'BioSamples': ['SAME123'],
+            'ENA': ['EXP123', 'EXP456']
+        }
+        submission = ExcelSubmission()
+        study = {
+            'study_accession': 'PRJEB12345'
+        }
+        sample = {
+            'sample_accession': 'SAME123'
+        }
+        run_experiment1 = {
+            'run_experiment_accession': 'EXP123',
+        }
+        run_experiment2 = {
+            'run_experiment_ena_accession': 'EXP456',
+        }
+        study_entity1 = ExcelLoader.map_row_entity(submission, 1, 'study', study)
+        sample_entity1 = ExcelLoader.map_row_entity(submission, 1, 'sample', sample)
+        run_entity1 = ExcelLoader.map_row_entity(submission, 1, 'run_experiment', run_experiment1)
+
+        study_entity2 = ExcelLoader.map_row_entity(submission, 2, 'study', study)
+        sample_entity2 = ExcelLoader.map_row_entity(submission, 2, 'sample', sample)
+        run_entity2 = ExcelLoader.map_row_entity(submission, 2, 'run_experiment', run_experiment2)
+
+        self.assertEqual(study_entity1, study_entity2)
+        self.assertEqual(sample_entity1, sample_entity2)
+        self.assertNotEqual(run_entity1, run_entity2)
+        
+        self.assertDictEqual(expected_accessions, submission.get_all_accessions())
+        self.assertEqual('PRJEB12345', study_entity1.identifier.index)
+        self.assertEqual('PRJEB12345', study_entity1.get_accession('BioStudies'))
+
+        self.assertEqual('SAME123', sample_entity1.identifier.index)
+        self.assertEqual('SAME123', sample_entity1.get_accession('BioSamples'))
+
+        self.assertEqual('EXP123', run_entity1.identifier.index)
+        self.assertEqual('EXP123', run_entity1.get_accession('ENA'))
+
+        # only accessions in the format {entity_type}_accession can be used for indexes
+        self.assertEqual('run_experiment:2', run_entity2.identifier.index)
+        self.assertEqual('EXP456', run_entity2.get_accession('ENA'))
+    
+    def test_unmapped_service_accessions(self):
+        expected_accessions = {
+            'BioSamples': ['SAME123'],
+            'BioStudies': ['PRJEB12345'],
+            'ENA': ['ENA-PROJECT-1', 'ENA-SAMPLE-1', 'EXP123', 'EXP456'],
+            'eva': ['EVA1', 'EVA2']
+        }
+        submission = ExcelSubmission()
+        study = {
+            'study_accession': 'PRJEB12345',
+            'study_ena_accession': 'ENA-PROJECT-1'
+        }
+        sample = {
+            'sample_accession': 'SAME123',
+            'sample_ena_accession': 'ENA-SAMPLE-1'
+        }
+        run_experiment1 = {
+            'run_experiment_accession': 'EXP123',
+            'run_experiment_eva_accession': 'EVA1'
+        }
+        run_experiment2 = {
+            'run_experiment_ena_accession': 'EXP456',
+            'run_experiment_eva_accession': 'EVA2'
+        }
+        study_entity1 = ExcelLoader.map_row_entity(submission, 1, 'study', study)
+        sample_entity1 = ExcelLoader.map_row_entity(submission, 1, 'sample', sample)
+        run_entity1 = ExcelLoader.map_row_entity(submission, 1, 'run_experiment', run_experiment1)
+
+        study_entity2 = ExcelLoader.map_row_entity(submission, 2, 'study', study)
+        sample_entity2 = ExcelLoader.map_row_entity(submission, 2, 'sample', sample)
+        run_entity2 = ExcelLoader.map_row_entity(submission, 2, 'run_experiment', run_experiment2)
+
+        self.assertEqual(study_entity1, study_entity2)
+        self.assertEqual(sample_entity1, sample_entity2)
+        self.assertNotEqual(run_entity1, run_entity2)
+        
+        self.assertDictEqual(expected_accessions, submission.get_all_accessions())
+        self.assertEqual('PRJEB12345', study_entity1.identifier.index)
+        self.assertEqual('PRJEB12345', study_entity1.get_accession('BioStudies'))
+        self.assertEqual('ENA-PROJECT-1', study_entity1.get_accession('ENA'))
+
+        self.assertEqual('SAME123', sample_entity1.identifier.index)
+        self.assertEqual('SAME123', sample_entity1.get_accession('BioSamples'))
+        self.assertEqual('ENA-SAMPLE-1', sample_entity1.get_accession('ENA'))
+
+        self.assertEqual('EXP123', run_entity1.identifier.index)
+        self.assertEqual('EXP123', run_entity1.get_accession('ENA'))
+        self.assertEqual('EVA1', run_entity1.get_accession('eva'))
+
+        # only accessions in the format {entity_type}_accession can be used for indexes
+        self.assertEqual('run_experiment:2', run_entity2.identifier.index)
+        self.assertEqual('EXP456', run_entity2.get_accession('ENA'))
+        self.assertEqual('EVA2', run_entity2.get_accession('eva'))


### PR DESCRIPTION
1. Cleanup CLI Error Reporting
2. Use the instructions column for reporting errors
    - This means not changing the columns of the spreadsheet so we don't "move" the notes added by the covid team
3. Merge Multiple errors when reported into the same cell
    - One cell might be reported as the cause for many issues, this change ensures that all issues will display in the error comment
4. Accession handling for multiple services
    - When adding an accession to an entity the user must specify the service for these accessions, these will be saved into the excel using the format `{entity_type}_{service}_accession`.
    - If the service is [mapped to the entity on ExcelLoader](https://github.com/ebi-ait/covid-excel-utils/blob/2f6fb6bd73c2da561c204407229b7b2c12d9e5ea/excel/load.py#L11) it will be treated as the default accession for that entity_type and saved `{entity_type}_accession`
    - When loading the same rules apply and accessions will be added for the relevant services if added in the excel attributes.
    - But all excel attributes are lowercase, so to map from `ena, biostudies, biosamples` to `ENA, BioStudies, BioSamples` there is a [lookup against the service name](https://github.com/ebi-ait/covid-excel-utils/blob/2f6fb6bd73c2da561c204407229b7b2c12d9e5ea/excel/load.py#L16). If no match found the lowercase form is used.
    - New unit tests for this functionality are [here](https://github.com/ebi-ait/covid-excel-utils/blob/2f6fb6bd73c2da561c204407229b7b2c12d9e5ea/test/unit/excel/test_accession_handling.py#L7).