### PR TITLE
Fix sample schema

### DIFF
--- a/validation/schema/sample.json
+++ b/validation/schema/sample.json
@@ -525,11 +525,11 @@
         "collection_date": {
           "description": "The date of sampling, either as an instance (single point in time) or interval. In case no exact time is available, the date/time can be right truncated i.e. all of these are valid ISO8601 compliant times: 2008-01-23T19:23:10+00:00; 2008-01-23T19:23:10; 2008-01-23; 2008-01; 2008.",
           "type": "string",
-          "not": {
-            "enum": [
-              "not applicable"
-            ]
-          }
+          "enum": [
+            "not provided",
+            "not collected",
+            "restricted access"
+          ]
         }
       }
     }

--- a/validation/schema/sample.json
+++ b/validation/schema/sample.json
@@ -510,7 +510,7 @@
       "type": "string"
     }
   },
-  "oneOf": [
+  "anyOf": [
     {
       "properties": {
         "collection_date": {


### PR DESCRIPTION
Changes:
- Replace `oneOf` keyword to `anyOf` in sample's JSON schema

I just realised that I accidentally reused the previous commit message for this current commit. Sorry for that.