### PR TITLE
ENA Conversion Accession Fixes

### DIFF
--- a/conversion/ena/base.py
+++ b/conversion/ena/base.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from typing import Iterable
 from xml.etree.ElementTree import Element
 
 from lxml import etree
@@ -22,7 +23,7 @@ class BaseEnaConverter:
         self.add_children(parent=root, children=xml_map)
         self.post_conversion(entity, root)
         return root
-    
+       
     @staticmethod
     def post_conversion(entity: Entity, xml_element: Element):
         pass
@@ -56,13 +57,13 @@ class BaseEnaConverter:
     @staticmethod
     def add_alias(spec: dict, entity: Entity):
         spec['@alias'] = ['', fixed_attribute, entity.identifier.index]
-        accession = entity.get_first_accession(['ENA', 'BioStudies', 'BioSamples'])
+        accession = entity.get_accession('ENA')
         if accession:
             spec['@accession'] = ['', fixed_attribute, accession]
 
     @staticmethod
-    def add_link(link: dict, entity: Entity):
+    def add_link(link: dict, entity: Entity, accession_services: Iterable[str]):
         link['@refname'] = ['', fixed_attribute, entity.identifier.index]
-        accession = entity.get_first_accession(['ENA', 'BioStudies', 'BioSamples'])
+        accession = entity.get_first_accession(accession_services)
         if accession:
             link['@accession'] = ['', fixed_attribute, accession]

--- a/conversion/ena/base.py
+++ b/conversion/ena/base.py
@@ -6,7 +6,7 @@ from lxml import etree
 from json_converter.json_mapper import JsonMapper
 from conversion.conversion_utils import fixed_attribute
 
-from submission.entity import Entity, EntityIdentifier
+from submission.entity import Entity
 
 
 class BaseEnaConverter:
@@ -63,7 +63,8 @@ class BaseEnaConverter:
 
     @staticmethod
     def add_link(link: dict, entity: Entity, accession_services: Iterable[str]):
-        link['@refname'] = ['', fixed_attribute, entity.identifier.index]
         accession = entity.get_first_accession(accession_services)
         if accession:
             link['@accession'] = ['', fixed_attribute, accession]
+        else:
+            link['@refname'] = ['', fixed_attribute, entity.identifier.index]

--- a/conversion/ena/experiment.py
+++ b/conversion/ena/experiment.py
@@ -34,12 +34,13 @@ EXPERIMENT_SPEC = {
         }
     }
 }
+EXPERIMENT_ACCESSION_PRIORITY = ['ENA_Experiment']
 REMOVE_KEYS = ['experiment_accession', 'center_name', 'experiment_name', 'library_name', 'library_strategy', 'library_source', 'library_selection', 'insert_size', 'sequencing_platform', 'sequencing_instrument', 'uploaded_file_1', 'uploaded_file_2']
 
 
 class EnaExperimentConverter(BaseEnaConverter):
     def __init__(self):
-        super().__init__(root_name='EXPERIMENT', xml_spec=EXPERIMENT_SPEC)
+        super().__init__(ena_type='Experiment', xml_spec=EXPERIMENT_SPEC)
     
     def convert_experiment(self, experiment: Entity, sample: Entity, study: Entity) -> Element:
         spec = deepcopy(self.xml_spec)

--- a/conversion/ena/experiment.py
+++ b/conversion/ena/experiment.py
@@ -2,9 +2,11 @@ from copy import deepcopy
 from xml.etree.ElementTree import Element
 
 from lxml import etree
+from conversion.conversion_utils import fixed_attribute
 from submission.entity import Entity
 from .base import BaseEnaConverter
-
+from .sample import SAMPLE_ACCESSION_PRIORITY
+from .study import STUDY_ACCESSION_PRIORITY
 
 EXPERIMENT_SPEC = {
     '@center_name': ['center_name'],
@@ -22,7 +24,7 @@ EXPERIMENT_SPEC = {
                 'PAIRED': {
                     'NOMINAL_LENGTH': ['insert_size']
                 },
-                'SINGLE': ['$object', {}]
+                'SINGLE': ['', fixed_attribute, '']
             }  # , 'LIBRARY_CONSTRUCTION_PROTOCOL': ''
         }
     },
@@ -32,8 +34,6 @@ EXPERIMENT_SPEC = {
         }
     }
 }
-
-
 REMOVE_KEYS = ['experiment_accession', 'center_name', 'experiment_name', 'library_name', 'library_strategy', 'library_source', 'library_selection', 'insert_size', 'sequencing_platform', 'sequencing_instrument', 'uploaded_file_1', 'uploaded_file_2']
 
 
@@ -44,8 +44,8 @@ class EnaExperimentConverter(BaseEnaConverter):
     def convert_experiment(self, experiment: Entity, sample: Entity, study: Entity) -> Element:
         spec = deepcopy(self.xml_spec)
         
-        BaseEnaConverter.add_link(spec['DESIGN']['SAMPLE_DESCRIPTOR'], sample)
-        BaseEnaConverter.add_link(spec['STUDY_REF'], study)
+        BaseEnaConverter.add_link(spec['DESIGN']['SAMPLE_DESCRIPTOR'], sample, SAMPLE_ACCESSION_PRIORITY)
+        BaseEnaConverter.add_link(spec['STUDY_REF'], study, STUDY_ACCESSION_PRIORITY)
 
         if 'insert_size' in experiment.attributes and 'uploaded_file_2' in experiment.attributes:
             del spec['DESIGN']['LIBRARY_DESCRIPTOR']['LIBRARY_LAYOUT']['SINGLE']

--- a/conversion/ena/project.py
+++ b/conversion/ena/project.py
@@ -1,3 +1,4 @@
+from conversion.conversion_utils import fixed_attribute
 from .base import BaseEnaConverter
 
 
@@ -6,9 +7,9 @@ PROJECT_SPEC = {
     'NAME': ['study_name'],
     'TITLE': ['short_description'],
     'DESCRIPTION': ['abstract'],
-    'SUBMISSION_PROJECT': ['$object', {
-        'SEQUENCING_PROJECT': {}
-    }]  # $object keyword for JSON Literal
+    'SUBMISSION_PROJECT': {
+        'SEQUENCING_PROJECT': ['', fixed_attribute, '']
+    }
 }
 
 

--- a/conversion/ena/project.py
+++ b/conversion/ena/project.py
@@ -15,4 +15,4 @@ PROJECT_SPEC = {
 
 class EnaProjectConverter(BaseEnaConverter):
     def __init__(self):
-        super().__init__(root_name='PROJECT', xml_spec=PROJECT_SPEC)
+        super().__init__(ena_type='Project', xml_spec=PROJECT_SPEC)

--- a/conversion/ena/run.py
+++ b/conversion/ena/run.py
@@ -4,6 +4,7 @@ from xml.etree.ElementTree import Element
 from lxml import etree
 from submission.entity import Entity
 from .base import BaseEnaConverter
+from .experiment import EXPERIMENT_ACCESSION_PRIORITY
 
 RUN_SPEC = {
     '@center_name': ['center_name'],
@@ -12,13 +13,14 @@ RUN_SPEC = {
 }
 REMOVE_KEYS = ['experiment_accession', 'center_name', 'experiment_name', 'library_name', 'library_strategy', 'library_source', 'library_selection', 'insert_size', 'sequencing_platform', 'sequencing_instrument', 'uploaded_file_1', 'uploaded_file_2']
 
+
 class EnaRunConverter(BaseEnaConverter):
     def __init__(self):
-        super().__init__(root_name='RUN', xml_spec=RUN_SPEC)
+        super().__init__(ena_type='Run', xml_spec=RUN_SPEC)
     
     def convert_run(self, run: Entity, experiment: Entity) -> Element:
         spec = deepcopy(self.xml_spec)
-        BaseEnaConverter.add_link(spec['EXPERIMENT_REF'], experiment, ['ENA'])
+        BaseEnaConverter.add_link(spec['EXPERIMENT_REF'], experiment, EXPERIMENT_ACCESSION_PRIORITY)
         return super().convert(run, xml_spec=spec)
 
     @staticmethod

--- a/conversion/ena/run.py
+++ b/conversion/ena/run.py
@@ -5,16 +5,12 @@ from lxml import etree
 from submission.entity import Entity
 from .base import BaseEnaConverter
 
-
 RUN_SPEC = {
     '@center_name': ['center_name'],
     'TITLE': ['experiment_name'],
     'EXPERIMENT_REF': {}
 }
-
-
 REMOVE_KEYS = ['experiment_accession', 'center_name', 'experiment_name', 'library_name', 'library_strategy', 'library_source', 'library_selection', 'insert_size', 'sequencing_platform', 'sequencing_instrument', 'uploaded_file_1', 'uploaded_file_2']
-
 
 class EnaRunConverter(BaseEnaConverter):
     def __init__(self):
@@ -22,7 +18,7 @@ class EnaRunConverter(BaseEnaConverter):
     
     def convert_run(self, run: Entity, experiment: Entity) -> Element:
         spec = deepcopy(self.xml_spec)
-        BaseEnaConverter.add_link(spec['EXPERIMENT_REF'], experiment)
+        BaseEnaConverter.add_link(spec['EXPERIMENT_REF'], experiment, ['ENA'])
         return super().convert(run, xml_spec=spec)
 
     @staticmethod

--- a/conversion/ena/sample.py
+++ b/conversion/ena/sample.py
@@ -16,14 +16,14 @@ SAMPLE_SPEC = {
     },
     'DESCRIPTION': ['sample_description']
 }
-SAMPLE_ACCESSION_PRIORITY = ['ENA', 'BioSamples']
+SAMPLE_ACCESSION_PRIORITY = ['BioSamples', 'ENA_Sample']
 REMOVE_KEYS = ['sample_accession', 'sample_alias', 'center_name', 'broker_name', 'sample_title',
                'sample_description', 'tax_id', 'scientific_name', 'common_name']
 
 
 class EnaSampleConverter(BaseEnaConverter):
     def __init__(self):
-        super().__init__(root_name='SAMPLE', xml_spec=SAMPLE_SPEC)
+        super().__init__(ena_type='Sample', xml_spec=SAMPLE_SPEC)
 
     @staticmethod
     def post_conversion(entity: Entity, xml_element: Element):

--- a/conversion/ena/sample.py
+++ b/conversion/ena/sample.py
@@ -16,8 +16,7 @@ SAMPLE_SPEC = {
     },
     'DESCRIPTION': ['sample_description']
 }
-
-
+SAMPLE_ACCESSION_PRIORITY = ['ENA', 'BioSamples']
 REMOVE_KEYS = ['sample_accession', 'sample_alias', 'center_name', 'broker_name', 'sample_title',
                'sample_description', 'tax_id', 'scientific_name', 'common_name']
 

--- a/conversion/ena/study.py
+++ b/conversion/ena/study.py
@@ -18,13 +18,13 @@ STUDY_SPEC = {
         }
     }
 }
-STUDY_ACCESSION_PRIORITY = ['ENA', 'BioStudies']
+STUDY_ACCESSION_PRIORITY = ['ENA_Project', 'ENA_Study']
 REMOVE_KEYS = ['study_accession', 'study_alias', 'center_name', 'study_name', 'short_description', 'abstract', 'study_name']
 
 
 class EnaStudyConverter(BaseEnaConverter):
     def __init__(self):
-        super().__init__(root_name='STUDY', xml_spec=STUDY_SPEC)
+        super().__init__(ena_type='Study', xml_spec=STUDY_SPEC)
     
     @staticmethod
     def post_conversion(entity: Entity, xml_element: Element):

--- a/conversion/ena/study.py
+++ b/conversion/ena/study.py
@@ -18,7 +18,7 @@ STUDY_SPEC = {
         }
     }
 }
-
+STUDY_ACCESSION_PRIORITY = ['ENA', 'BioStudies']
 REMOVE_KEYS = ['study_accession', 'study_alias', 'center_name', 'study_name', 'short_description', 'abstract', 'study_name']
 
 

--- a/conversion/ena/submission.py
+++ b/conversion/ena/submission.py
@@ -49,7 +49,8 @@ class EnaSubmissionConverter:
         sample_converter = EnaSampleConverter()
         samples_node = etree.XML('<SAMPLE_SET />')
         for sample in data.get_entities('sample'):
-            samples_node.append(sample_converter.convert(sample))
+            if not sample.get_accession('BioSamples'):
+                samples_node.append(sample_converter.convert(sample))
         return samples_node
 
     @staticmethod

--- a/conversion/ena/submission.py
+++ b/conversion/ena/submission.py
@@ -62,15 +62,15 @@ class EnaSubmissionConverter:
 
             if len(samples) < 1 or len(studies) < 1:
                 if len(samples) < 1:
-                    experiment.add_error('experiment_accession', 'No Linked Sample')
+                    experiment.add_error('run_experiment_ena_experiment_accession', 'No Linked Sample')
                 if len(studies) < 1:
-                    experiment.add_error('experiment_accession', 'No Linked Study')
+                    experiment.add_error('run_experiment_ena_experiment_accession', 'No Linked Study')
             else:
                 # ENA Only supports linking one study & sample to an experiment
                 if len(samples) > 1:
-                    experiment.add_error(f'More than one Sample Linked, using first: {samples[0].identifier.index}')
+                    experiment.add_error('run_experiment_ena_experiment_accession', f'More than one Sample Linked, using first: {samples[0].identifier.index}')
                 if len(studies) > 1:
-                    experiment.add_error(f'More than one Study Linked, using first: {studies[0].identifier.index}')
+                    experiment.add_error('run_experiment_ena_experiment_accession', f'More than one Study Linked, using first: {studies[0].identifier.index}')
                 experiments_node.append(experiment_converter.convert_experiment(experiment, samples[0], studies[0]))
         return experiments_node
 
@@ -93,10 +93,12 @@ class EnaSubmissionConverter:
             study: Entity
             for study in data.get_entities('study'):
                 if 'release_date' in study.attributes:
-                    release_dates.add(study.attributes['release_date'])
+                    release_date = date.fromisoformat(study.attributes['release_date'])
+                    if release_date > date.today():
+                        release_dates.add(release_date)
             if len(release_dates) > 0:
                 # Use first study release date, possible that file includes many 
-                release_date = date.fromisoformat(release_dates.pop())
+                release_date = release_dates.pop()
                 action_hold = etree.SubElement(actions, 'ACTION')
                 hold = etree.SubElement(action_hold, 'HOLD')
                 hold.attrib['HoldUntilDate'] = release_date.isoformat()

--- a/conversion/ena/submission.py
+++ b/conversion/ena/submission.py
@@ -25,7 +25,9 @@ class EnaSubmissionConverter:
     def convert(self, data: Submission) -> dict:
         ena_files = {}
         for file_name, converter in self.conversions.items():
-            ena_files[file_name] = converter(data)
+            file_node = converter(data)
+            if file_node:
+                ena_files[file_name] = file_node
         return ena_files
 
     @staticmethod
@@ -34,7 +36,8 @@ class EnaSubmissionConverter:
         projects_node = etree.XML('<PROJECT_SET />')
         for study in data.get_entities('study'):
             projects_node.append(project_converter.convert(study))
-        return projects_node
+        if len(projects_node):
+            return projects_node
 
     @staticmethod
     def studies_file(data: Submission) -> Element:
@@ -42,7 +45,8 @@ class EnaSubmissionConverter:
         studies_node = etree.XML('<STUDY_SET />')
         for study in data.get_entities('study'):
             studies_node.append(study_converter.convert(study))
-        return studies_node
+        if len(studies_node):
+            return studies_node
 
     @staticmethod
     def samples_file(data: Submission) -> Element:
@@ -51,7 +55,8 @@ class EnaSubmissionConverter:
         for sample in data.get_entities('sample'):
             if not sample.get_accession('BioSamples'):
                 samples_node.append(sample_converter.convert(sample))
-        return samples_node
+        if len(samples_node):
+            return samples_node
 
     @staticmethod
     def experiments_file(data: Submission) -> Element:
@@ -73,7 +78,8 @@ class EnaSubmissionConverter:
                 if len(studies) > 1:
                     experiment.add_error('run_experiment_ena_experiment_accession', f'More than one Study Linked, using first: {studies[0].identifier.index}')
                 experiments_node.append(experiment_converter.convert_experiment(experiment, samples[0], studies[0]))
-        return experiments_node
+        if len(experiments_node):
+            return experiments_node
 
     @staticmethod
     def runs_file(data: Submission) -> Element:
@@ -81,7 +87,8 @@ class EnaSubmissionConverter:
         runs_node = etree.XML('<RUN_SET />')
         for run in data.get_entities('run_experiment'):
             runs_node.append(run_converter.convert_run(run, experiment=run))
-        return runs_node
+        if len(runs_node):
+            return runs_node
     
     @staticmethod
     def submission_file(data: Submission) -> Element:

--- a/excel/load.py
+++ b/excel/load.py
@@ -11,12 +11,16 @@ POSSIBLE_KEYS = ['alias', 'index', 'name']
 SERVICE_MAP = {
     'study': 'BioStudies',
     'sample': 'BioSamples',
-    'run_experiment': 'ENA'
+    'run_experiment': 'ENA_Run'
 }
 SERVICE_NAMES = {
     'BioStudies'.lower(): 'BioStudies',
     'BioSamples'.lower(): 'BioSamples',
-    'ENA'.lower(): 'ENA'
+    'ENA_Project'.lower(): 'ENA_Project',
+    'ENA_Study'.lower(): 'ENA_Study',
+    'ENA_Sample'.lower(): 'ENA_Sample',
+    'ENA_Experiment'.lower(): 'ENA_Experiment',
+    'ENA_Run'.lower(): 'ENA_Run'
 }
 
 

--- a/excel/load.py
+++ b/excel/load.py
@@ -89,7 +89,7 @@ class ExcelLoader:
         else:
             index = ExcelLoader.get_index(entity_type, row, attributes)
         entity = submission.map_row(row, entity_type, index, attributes)
-        if accession:
+        if accession and entity_type in SERVICE_MAP:
             entity.add_accession(SERVICE_MAP[entity_type], accession)
         ExcelLoader.add_entity_accessions(entity, ignore=[accession_attribute])
         return entity

--- a/services/biostudies.py
+++ b/services/biostudies.py
@@ -15,8 +15,9 @@ BIOSTUDIES_LINK_TYPES = {
 
 ENTITY_TYPE_SERVICE = {
     'sample': 'BioSamples',
-    'run_experiment': 'ENA'
+    'run_experiment': 'ENA_Run'
 }
+
 
 class BioStudies:
     def __init__(self, base_url=None, username=None, password=None):

--- a/submission/entity.py
+++ b/submission/entity.py
@@ -38,7 +38,7 @@ class Entity:
     def get_accession(self, service: str) -> str:
         return self.__accessions.get(service, None)
 
-    def get_first_accession(self, service_priority):
+    def get_first_accession(self, service_priority: Iterable[str]):
         for service in service_priority:
             accession = self.get_accession(service)
             if accession:

--- a/test/unit/excel/test_accession_handling.py
+++ b/test/unit/excel/test_accession_handling.py
@@ -124,4 +124,4 @@ class TestExcelAccessionHandling(unittest.TestCase):
         lorem_entity = ExcelLoader.map_row_entity(submission, 1, 'lorem', attributes)
 
         self.assertEqual('ipsum', lorem_entity.identifier.index)
-        self.assertDictEqual({}, lorem_entity.__accessions)
+        self.assertFalse(lorem_entity.get_accessions())

--- a/test/unit/excel/test_accession_handling.py
+++ b/test/unit/excel/test_accession_handling.py
@@ -5,101 +5,123 @@ from excel.submission import ExcelSubmission
 
 
 class TestExcelAccessionHandling(unittest.TestCase):
-    def test_adding_mapped_or_default_service_accessions(self):
+    def test_default_accessions(self):
         expected_accessions = {
-            'BioStudies': ['PRJEB12345'],
-            'BioSamples': ['SAME123'],
-            'ENA': ['EXP123', 'EXP456']
+            'BioStudies': ['S-BSST1'],
+            'BioSamples': ['SAME1'],
+            'ENA_Run': ['ERR1', 'ERR2']
         }
         submission = ExcelSubmission()
         study = {
-            'study_accession': 'PRJEB12345'
+            'study_accession': 'S-BSST1',
         }
         sample = {
-            'sample_accession': 'SAME123'
+            'sample_accession': 'SAME1',
         }
         run_experiment1 = {
-            'run_experiment_accession': 'EXP123',
+            'run_experiment_accession': 'ERR1',
         }
         run_experiment2 = {
-            'run_experiment_ena_accession': 'EXP456',
+            'run_experiment_accession': 'ERR2',
         }
         study_entity1 = ExcelLoader.map_row_entity(submission, 1, 'study', study)
         sample_entity1 = ExcelLoader.map_row_entity(submission, 1, 'sample', sample)
         run_entity1 = ExcelLoader.map_row_entity(submission, 1, 'run_experiment', run_experiment1)
-
-        study_entity2 = ExcelLoader.map_row_entity(submission, 2, 'study', study)
-        sample_entity2 = ExcelLoader.map_row_entity(submission, 2, 'sample', sample)
         run_entity2 = ExcelLoader.map_row_entity(submission, 2, 'run_experiment', run_experiment2)
-
-        self.assertEqual(study_entity1, study_entity2)
-        self.assertEqual(sample_entity1, sample_entity2)
-        self.assertNotEqual(run_entity1, run_entity2)
         
         self.assertDictEqual(expected_accessions, submission.get_all_accessions())
-        self.assertEqual('PRJEB12345', study_entity1.identifier.index)
-        self.assertEqual('PRJEB12345', study_entity1.get_accession('BioStudies'))
+        self.assertEqual('S-BSST1', study_entity1.identifier.index)
+        self.assertEqual('S-BSST1', study_entity1.get_accession('BioStudies'))
 
-        self.assertEqual('SAME123', sample_entity1.identifier.index)
-        self.assertEqual('SAME123', sample_entity1.get_accession('BioSamples'))
+        self.assertEqual('SAME1', sample_entity1.identifier.index)
+        self.assertEqual('SAME1', sample_entity1.get_accession('BioSamples'))
 
-        self.assertEqual('EXP123', run_entity1.identifier.index)
-        self.assertEqual('EXP123', run_entity1.get_accession('ENA'))
+        self.assertEqual('ERR1', run_entity1.identifier.index)
+        self.assertEqual('ERR1', run_entity1.get_accession('ENA_Run'))
 
-        # only accessions in the format {entity_type}_accession can be used for indexes
-        self.assertEqual('run_experiment:2', run_entity2.identifier.index)
-        self.assertEqual('EXP456', run_entity2.get_accession('ENA'))
+        self.assertEqual('ERR2', run_entity2.identifier.index)
+        self.assertEqual('ERR2', run_entity2.get_accession('ENA_Run'))
     
+    def test_mapped_accessions(self):
+        expected_accessions = {
+            'BioStudies': ['S-BSST1'],
+            'BioSamples': ['SAME1'],
+            'ENA_Project': ['PRJEB1'],
+            'ENA_Study': ['ERP1'],
+            'ENA_Sample': ['ERS1'],
+            'ENA_Experiment': ['ERX1', 'ERX2'],
+            'ENA_Run': ['ERR1', 'ERR2']
+        }
+        submission = ExcelSubmission()
+        study = {
+            'study_biostudies_accession': 'S-BSST1',
+            'study_ena_project_accession': 'PRJEB1',
+            'study_ena_study_accession': 'ERP1'
+        }
+        sample = {
+            'sample_biosamples_accession': 'SAME1',
+            'sample_ena_sample_accession': 'ERS1'
+        }
+        run_experiment1 = {
+            'run_experiment_ena_experiment_accession': 'ERX1',
+            'run_experiment_ena_run_accession': 'ERR1',
+
+        }
+        run_experiment2 = {
+            'run_experiment_ena_experiment_accession': 'ERX2',
+            'run_experiment_ena_run_accession': 'ERR2',
+        }
+        study_entity1 = ExcelLoader.map_row_entity(submission, 1, 'study', study)
+        sample_entity1 = ExcelLoader.map_row_entity(submission, 1, 'sample', sample)
+        run_entity1 = ExcelLoader.map_row_entity(submission, 1, 'run_experiment', run_experiment1)
+        run_entity2 = ExcelLoader.map_row_entity(submission, 2, 'run_experiment', run_experiment2)
+        
+        self.assertDictEqual(expected_accessions, submission.get_all_accessions())
+        self.assertEqual('S-BSST1', study_entity1.get_accession('BioStudies'))
+        self.assertEqual('PRJEB1', study_entity1.get_accession('ENA_Project'))
+        self.assertEqual('ERP1', study_entity1.get_accession('ENA_Study'))
+
+        self.assertEqual('SAME1', sample_entity1.get_accession('BioSamples'))
+        self.assertEqual('ERS1', sample_entity1.get_accession('ENA_Sample'))
+
+        self.assertEqual('ERR1', run_entity1.get_accession('ENA_Run'))
+        self.assertEqual('ERX1', run_entity1.get_accession('ENA_Experiment'))
+
+        self.assertEqual('ERR2', run_entity2.get_accession('ENA_Run'))
+        self.assertEqual('ERX2', run_entity2.get_accession('ENA_Experiment'))
+
     def test_unmapped_service_accessions(self):
         expected_accessions = {
-            'BioSamples': ['SAME123'],
-            'BioStudies': ['PRJEB12345'],
-            'ENA': ['ENA-PROJECT-1', 'ENA-SAMPLE-1', 'EXP123', 'EXP456'],
+            'array_express': ['A1', 'A2'],
             'eva': ['EVA1', 'EVA2']
         }
         submission = ExcelSubmission()
-        study = {
-            'study_accession': 'PRJEB12345',
-            'study_ena_accession': 'ENA-PROJECT-1'
+        sequence1 = {
+            'sequence_array_express_accession': 'A1',
+            'sequence_eva_accession': 'EVA1',
         }
-        sample = {
-            'sample_accession': 'SAME123',
-            'sample_ena_accession': 'ENA-SAMPLE-1'
+        sequence2 = {
+            'sequence_array_express_accession': 'A2',
+            'sequence_eva_accession': 'EVA2',
         }
-        run_experiment1 = {
-            'run_experiment_accession': 'EXP123',
-            'run_experiment_eva_accession': 'EVA1'
-        }
-        run_experiment2 = {
-            'run_experiment_ena_accession': 'EXP456',
-            'run_experiment_eva_accession': 'EVA2'
-        }
-        study_entity1 = ExcelLoader.map_row_entity(submission, 1, 'study', study)
-        sample_entity1 = ExcelLoader.map_row_entity(submission, 1, 'sample', sample)
-        run_entity1 = ExcelLoader.map_row_entity(submission, 1, 'run_experiment', run_experiment1)
-
-        study_entity2 = ExcelLoader.map_row_entity(submission, 2, 'study', study)
-        sample_entity2 = ExcelLoader.map_row_entity(submission, 2, 'sample', sample)
-        run_entity2 = ExcelLoader.map_row_entity(submission, 2, 'run_experiment', run_experiment2)
-
-        self.assertEqual(study_entity1, study_entity2)
-        self.assertEqual(sample_entity1, sample_entity2)
-        self.assertNotEqual(run_entity1, run_entity2)
+        sequence_entity1 = ExcelLoader.map_row_entity(submission, 1, 'sequence', sequence1)
+        sequence_entity2 = ExcelLoader.map_row_entity(submission, 2, 'sequence', sequence2)
         
         self.assertDictEqual(expected_accessions, submission.get_all_accessions())
-        self.assertEqual('PRJEB12345', study_entity1.identifier.index)
-        self.assertEqual('PRJEB12345', study_entity1.get_accession('BioStudies'))
-        self.assertEqual('ENA-PROJECT-1', study_entity1.get_accession('ENA'))
+        self.assertEqual('A1', sequence_entity1.get_accession('array_express'))
+        self.assertEqual('EVA1', sequence_entity1.get_accession('eva'))
+        self.assertEqual('A2', sequence_entity2.get_accession('array_express'))
+        self.assertEqual('EVA2', sequence_entity2.get_accession('eva'))
+        
+    def test_umnapped_no_service_accession(self):
+        # In the case that {object}_accession is used in the excel for an object that isn't configured with a default service
+        # Use the accession as an index but do not add the accession to the entity.
+        attributes = {
+            'lorem_accession': 'ipsum'
+        }
 
-        self.assertEqual('SAME123', sample_entity1.identifier.index)
-        self.assertEqual('SAME123', sample_entity1.get_accession('BioSamples'))
-        self.assertEqual('ENA-SAMPLE-1', sample_entity1.get_accession('ENA'))
+        submission = ExcelSubmission()
+        lorem_entity = ExcelLoader.map_row_entity(submission, 1, 'lorem', attributes)
 
-        self.assertEqual('EXP123', run_entity1.identifier.index)
-        self.assertEqual('EXP123', run_entity1.get_accession('ENA'))
-        self.assertEqual('EVA1', run_entity1.get_accession('eva'))
-
-        # only accessions in the format {entity_type}_accession can be used for indexes
-        self.assertEqual('run_experiment:2', run_entity2.identifier.index)
-        self.assertEqual('EXP456', run_entity2.get_accession('ENA'))
-        self.assertEqual('EVA2', run_entity2.get_accession('eva'))
+        self.assertEqual('ipsum', lorem_entity.identifier.index)
+        self.assertDictEqual({}, lorem_entity.__accessions)

--- a/test/unit/excel/test_loading.py
+++ b/test/unit/excel/test_loading.py
@@ -1,0 +1,90 @@
+import unittest
+
+from excel.load import ExcelLoader
+from excel.submission import ExcelSubmission
+
+
+class TestExcelLoading(unittest.TestCase):
+    def test_loading_accession_equality(self):
+        submission = ExcelSubmission()
+        study_entity1 = ExcelLoader.map_row_entity(submission, 1, 'study', {'study_accession': 'STUD1'})
+        sample_entity1 = ExcelLoader.map_row_entity(submission, 1, 'sample', {'sample_accession': 'SAME1'})
+
+        study_entity2 = ExcelLoader.map_row_entity(submission, 2, 'study', {'study_accession': 'STUD1'})
+        sample_entity2 = ExcelLoader.map_row_entity(submission, 2, 'sample', {'sample_accession': 'SAME2'})
+
+        self.assertEqual(study_entity1, study_entity2)
+        self.assertNotEqual(sample_entity1, sample_entity2)
+
+    def test_loading_index_equality(self):
+        submission = ExcelSubmission()
+        study_entity1 = ExcelLoader.map_row_entity(submission, 1, 'study', {'study_alias': 'STUD1'})
+        sample_entity1 = ExcelLoader.map_row_entity(submission, 1, 'sample', {'sample_index': 'SAME1'})
+        run_entity1 = ExcelLoader.map_row_entity(submission, 1, 'run', {'run_name': 'John'})
+
+        study_entity2 = ExcelLoader.map_row_entity(submission, 2, 'study', {'study_alias': 'STUD1'})
+        sample_entity2 = ExcelLoader.map_row_entity(submission, 2, 'sample', {'sample_index': 'SAME1'})
+        run_entity2 = ExcelLoader.map_row_entity(submission, 2, 'run', {'run_name': 'Jill'})
+
+        self.assertEqual(study_entity1, study_entity2)
+        self.assertEqual(sample_entity1, sample_entity2)
+        self.assertNotEqual(run_entity1, run_entity2)
+    
+    def test_loading_without_index(self):
+        submission = ExcelSubmission()
+        entity1 = ExcelLoader.map_row_entity(submission, 1, 'lorem', {})
+        entity2 = ExcelLoader.map_row_entity(submission, 2, 'ipsum', {})
+
+        self.assertNotEqual(entity1, entity2)
+        self.assertEqual('lorem:1', entity1.identifier.index)
+        self.assertEqual('ipsum:2', entity2.identifier.index)
+    
+    def test_links(self):
+        submission = ExcelSubmission()
+        study_entity1 = ExcelLoader.map_row_entity(submission, 1, 'study', {'study_accession': 'STUD1'})
+        sample_entity1 = ExcelLoader.map_row_entity(submission, 1, 'sample', {'sample_accession': 'SAME1'})
+        run_entity1 = ExcelLoader.map_row_entity(submission, 1, 'run_experiment', {'run_experiment_accession': 'RUN1'})
+        ExcelLoader.map_row_entity(submission, 2, 'study', {'study_accession': 'STUD1'})
+        ExcelLoader.map_row_entity(submission, 2, 'sample', {'sample_accession': 'SAME1'})
+        run_entity2 = ExcelLoader.map_row_entity(submission, 2, 'run_experiment', {'run_experiment_accession': 'RUN2'})
+        
+        self.assertSetEqual({'SAME1'}, study_entity1.get_linked_indexes('sample'))
+        self.assertSetEqual({'RUN1', 'RUN2'}, study_entity1.get_linked_indexes('run_experiment'))
+
+        self.assertSetEqual({'STUD1'}, sample_entity1.get_linked_indexes('study'))
+        self.assertSetEqual({'RUN1', 'RUN2'}, sample_entity1.get_linked_indexes('run_experiment'))
+
+        self.assertSetEqual({'STUD1'}, run_entity1.get_linked_indexes('study'))
+        self.assertSetEqual({'SAME1'}, run_entity1.get_linked_indexes('sample'))
+
+        self.assertSetEqual({'STUD1'}, run_entity2.get_linked_indexes('study'))
+        self.assertSetEqual({'SAME1'}, run_entity2.get_linked_indexes('sample'))
+
+    def test_loading_differing_index_equality(self):
+        # Note: I'm not sure if this is a feature or a bug so if this test fails it's okay,
+        # but it's a situation worth noting about our current implementation
+        s_1 = {
+            's_alias': 'STUD',
+            's_index': 'over-written index1',
+            's_name': 'over-written name1'
+        }
+        s_2 = {
+            's_index': 'STUD',
+            's_name': 'over-written name2'
+        }
+        s_3 = {
+            's_name': 'STUD'
+        }
+        expected_s = {
+            's_alias': 'STUD',
+            's_index': 'STUD',
+            's_name': 'STUD'
+        }
+        submission = ExcelSubmission()
+        s_entity1 = ExcelLoader.map_row_entity(submission, 1, 's', s_1)
+        s_entity2 = ExcelLoader.map_row_entity(submission, 2, 's', s_2)
+        s_entity3 = ExcelLoader.map_row_entity(submission, 3, 's', s_3)
+
+        self.assertEqual(s_entity1, s_entity2)
+        self.assertEqual(s_entity1, s_entity3)        
+        self.assertDictEqual(expected_s, s_entity1.attributes)


### PR DESCRIPTION
Fixes to the ENA Conversion functionality to do with accessions:
- [x] ENA links use either accession of rename but not both
- [x] Don't populate submission hold date if date is in the past
- [x] Specify ENA accessions as either `ENA_Project`,`ENA_Study`,`ENA_Sample`,`ENA_Experiment`,`ENA_Run`
- [x] This allows one study entity to reference both `ENA_Project`,`ENA_Study` and one run_experiment entity to reference both `ENA_Experiment`,`ENA_Run`
- [x] Don't Create ENA Sample for samples with a BioSamples Accession
- [x] Don't Add file to output if root node is empty (in the case that no samples are required for ENA)
- [x] Fix Unit Tests