### PR TITLE
Webin Manifest Option

### DIFF
--- a/conversion/ena/experiment.py
+++ b/conversion/ena/experiment.py
@@ -48,7 +48,7 @@ class EnaExperimentConverter(BaseEnaConverter):
         BaseEnaConverter.add_link(spec['DESIGN']['SAMPLE_DESCRIPTOR'], sample, SAMPLE_ACCESSION_PRIORITY)
         BaseEnaConverter.add_link(spec['STUDY_REF'], study, STUDY_ACCESSION_PRIORITY)
 
-        if 'insert_size' in experiment.attributes and 'uploaded_file_2' in experiment.attributes:
+        if EnaExperimentConverter.is_paired_fastq(experiment):
             del spec['DESIGN']['LIBRARY_DESCRIPTOR']['LIBRARY_LAYOUT']['SINGLE']
         else:
             del spec['DESIGN']['LIBRARY_DESCRIPTOR']['LIBRARY_LAYOUT']['PAIRED']
@@ -59,6 +59,13 @@ class EnaExperimentConverter(BaseEnaConverter):
             del spec['PLATFORM']
         
         return super().convert(entity=experiment, xml_spec=spec)
+
+    @staticmethod
+    def is_paired_fastq(experiment: Entity) -> bool:
+        return 'insert_size' in experiment.attributes and \
+            'uploaded_file_2' in experiment.attributes and \
+            'fastq' in experiment.attributes['uploaded_file_1'].lower() and \
+            'fastq' in experiment.attributes['uploaded_file_2'].lower()
 
     @staticmethod
     def post_conversion(entity: Entity, xml_element: Element):

--- a/conversion/ena/manifest.py
+++ b/conversion/ena/manifest.py
@@ -26,10 +26,10 @@ class EnaManifestConverter:
                 sample = samples.pop()
                 study = studies.pop()
                 sample_accession = sample.get_first_accession(SAMPLE_ACCESSION_PRIORITY)
-                study_accession = study.get_first_accession('ENA_Study')
+                study_accession = study.get_accession('ENA_Study')
                 if sample_accession and study_accession:
                     file_name, content = self.make_manifest(run_experiment, sample_accession, study_accession)
-                manifests[file_name] = content
+                    manifests[file_name] = content
         return manifests
 
     def make_manifest(self, run_experiment: Entity, sample_accession: str, study_accession: str) -> Tuple[str, str]:

--- a/conversion/ena/manifest.py
+++ b/conversion/ena/manifest.py
@@ -1,0 +1,99 @@
+from typing import Dict, Tuple
+
+from submission.entity import Entity
+from submission.submission import Submission
+from .sample import SAMPLE_ACCESSION_PRIORITY
+from .experiment import EnaExperimentConverter
+from .run import EnaRunConverter
+
+SUBMISSION_TOOL = "drag and drop uploader tool"
+
+
+class EnaManifestConverter:
+    def __init__(self, schema:dict):
+        self.platforms = schema.get('properties', {}).get('sequencing_platform', {}).get('enum', [])
+        self.instruments = schema.get('properties', {}).get('sequencing_instrument', {}).get('enum', [])
+        self.library_sources = schema.get('properties', {}).get('library_source', {}).get('enum', [])
+        self.library_selections = schema.get('properties', {}).get('library_selection', {}).get('enum', [])
+        self.library_strategies = schema.get('properties', {}).get('library_strategy', {}).get('enum', [])
+
+    def make_manifests(self, submission: Submission) -> Dict[str, str]:
+        manifests = {}
+        for run_experiment in submission.get_entities('run_experiment'):
+            samples = submission.get_linked_entities(run_experiment, 'sample')
+            studies = submission.get_linked_entities(run_experiment, 'study')
+            if len(samples) == 1 and len(studies) == 1 and 'uploaded_file_1' in run_experiment.attributes:
+                sample = samples.pop()
+                study = studies.pop()
+                sample_accession = sample.get_first_accession(SAMPLE_ACCESSION_PRIORITY)
+                study_accession = study.get_first_accession('ENA_Study')
+                if sample_accession and study_accession:
+                    file_name, content = self.make_manifest(run_experiment, sample_accession, study_accession)
+                manifests[file_name] = content
+        return manifests
+
+    def make_manifest(self, run_experiment: Entity, sample_accession: str, study_accession: str) -> Tuple[str, str]:
+        manifest_lines = []
+        manifest_lines.append(f'STUDY\t{study_accession}')
+        manifest_lines.append(f'SAMPLE\t{sample_accession}')
+        manifest_lines.append(f'NAME\t{run_experiment.identifier.index}')
+
+        platform = self.valid_platform(run_experiment.attributes.get('sequencing_platform', ''))
+        if platform:
+            manifest_lines.append(f'PLATFORM\t{platform}')
+
+        instrument = self.valid_instrument(run_experiment.attributes.get('sequencing_instrument', ''))
+        manifest_lines.append(f'INSTRUMENT\t{instrument}')
+        
+        paired_fastq = EnaExperimentConverter.is_paired_fastq(run_experiment)
+        if paired_fastq:
+            manifest_lines.append(f"INSERT_SIZE\t{run_experiment.attributes['insert_size']}")
+        
+        library_name = run_experiment.attributes.get('library_name', '')
+        if library_name:
+            manifest_lines.append(f'LIBRARY_NAME\t{library_name}')
+        
+        library_source = self.valid_library_source(run_experiment.attributes.get('library_source', ''))
+        manifest_lines.append(f'LIBRARY_SOURCE\t{library_source}')
+
+        library_selection = self.valid_library_selection(run_experiment.attributes.get('library_selection', 'unspecified'))
+        manifest_lines.append(f'LIBRARY_SELECTION\t{library_selection}')
+
+        library_strategy = self.valid_library_strategy(run_experiment.attributes.get('library_strategy', ''))
+        manifest_lines.append(f'LIBRARY_STRATEGY\t{library_strategy}')
+        manifest_lines.append(f'SUBMISSION_TOOL\t{SUBMISSION_TOOL}')
+
+        file_name = run_experiment.attributes['uploaded_file_1']
+        file_type = EnaRunConverter.get_file_type(file_name).upper()
+        manifest_lines.append(f'{file_type}\t{file_name}')
+        if paired_fastq:
+            paired_file = run_experiment.attributes['uploaded_file_2']
+            file_name += f'.{paired_file}'
+            manifest_lines.append(f'{file_type}\t{paired_file}')
+        file_name += '.manifest'
+        return file_name, '\n'.join(manifest_lines)
+
+    def valid_platform(self, platform: str) -> str:
+        converted_platform = platform.upper().replace(' ', '_')
+        if converted_platform in self.platforms:
+            return converted_platform
+
+    def valid_instrument(self, instrument: str) -> str:
+        if instrument in self.instruments:
+            return instrument
+        return 'unspecified'
+
+    def valid_library_source(self, library_source: str) -> str:
+        if library_source in self.library_sources:
+            return library_source
+        return 'OTHER'
+
+    def valid_library_selection(self, library_selection: str) -> str:
+        if library_selection in self.library_selections:
+            return library_selection
+        return 'other'
+    
+    def valid_library_strategy(self, library_strategy: str) -> str:
+        if library_strategy in self.library_strategies:
+            return library_strategy
+        return 'OTHER'

--- a/conversion/ena/submission.py
+++ b/conversion/ena/submission.py
@@ -58,13 +58,16 @@ class EnaSubmissionConverter:
             if len(studies) < 1:
                 experiment.add_error('run_experiment_ena_experiment_accession', 'No Linked Study')
         else:
-            # ENA Only supports linking one study & sample to an experiment
-            if len(samples) > 1:
-                experiment.add_error('run_experiment_ena_experiment_accession', f'More than one Sample Linked, using first: {samples[0].identifier.index}')
-            if len(studies) > 1:
-                experiment.add_error('run_experiment_ena_experiment_accession', f'More than one Study Linked, using first: {studies[0].identifier.index}')
+            len_samples = len(samples)
+            len_studies = len(studies)
             sample = samples.pop()
             study = studies.pop()
+
+            # ENA Only supports linking one study & sample to an experiment
+            if len_samples > 1:
+                experiment.add_error('run_experiment_ena_experiment_accession', f'More than one Sample Linked, using first: {sample.identifier.index}')
+            if len_studies > 1:
+                experiment.add_error('run_experiment_ena_experiment_accession', f'More than one Study Linked, using first: {study.identifier.index}')
             return converter.convert_experiment(experiment, sample, study)
 
     @staticmethod

--- a/excel/load.py
+++ b/excel/load.py
@@ -1,3 +1,4 @@
+import logging
 from contextlib import closing
 from typing import List
 
@@ -60,6 +61,8 @@ class ExcelLoader:
             if attribute_cell.value is not None:
                 column_info['attribute'] = clean_name(attribute_cell.value)
                 column_map[attribute_cell.column_letter] = column_info
+            else:
+                logging.warning(f'No heading found for column: {attribute_cell.column_letter}, values will not be imported.')
         return column_map
 
     @staticmethod
@@ -76,9 +79,10 @@ class ExcelLoader:
                         value = cell.value.date().isoformat()
                     else:
                         value = str(cell.value).strip()
-                    object_name = column_map[cell.column_letter]['object']
-                    attribute_name = column_map[cell.column_letter]['attribute']
-                    row_data.setdefault(object_name, {})[attribute_name] = value
+                    if cell.column_letter in column_map:
+                        object_name = column_map[cell.column_letter]['object']
+                        attribute_name = column_map[cell.column_letter]['attribute']
+                        row_data.setdefault(object_name, {})[attribute_name] = value
             for entity_type, attributes in row_data.items():
                 ExcelLoader.map_row_entity(data, row_index, entity_type, attributes)
 

--- a/validation/upload.py
+++ b/validation/upload.py
@@ -4,6 +4,7 @@ import io
 from typing import Dict
 
 import boto3
+from botocore.exceptions import ClientError
 
 from submission.entity import Entity
 from submission.submission import Submission
@@ -52,7 +53,12 @@ class UploadValidator(BaseValidator):
     
     @staticmethod
     def get_file_checksum_map(folder_uuid: str) -> Dict[str, str]:
-        checksums_text = UploadValidator.get_checksums_file(f'{folder_uuid}/{CHECKSUMS_FILE_NAME}')
+        try:
+            checksums_text = UploadValidator.get_checksums_file(f'{folder_uuid}/{CHECKSUMS_FILE_NAME}')
+        except ClientError as error:
+            checksums_text = ''
+            error_info = error.response.get('Error', {})
+            logging.warning(f"Could not get checksums from drag-and-drop server: {error_info.get('Code', 'Unknown')} {error_info.get('Message', 'Unknown')}")
         file_checksum_map = {}
         for line in checksums_text.splitlines():
             file_name, _, file_checksum = line.strip().partition(',')

--- a/validation/xsd.py
+++ b/validation/xsd.py
@@ -1,33 +1,34 @@
 import logging
+import re
 from fnmatch import fnmatch
 from os import listdir
 from os.path import dirname, join, splitext
-import re
 
 from lxml import etree
 
 from submission.submission import Submission
 from submission.entity import Entity
-from conversion.ena.submission import EnaSubmissionConverter, CONVERSION_MAP
+from conversion.ena.submission import EnaSubmissionConverter
 from .base import BaseValidator
 
 
 class XMLSchemaValidator(BaseValidator):
     ena_schema = {}
 
-    def __init__(self):
+    def __init__(self, ena_converter: EnaSubmissionConverter):
         self.__load_schema_files()
+        self.converter = ena_converter
         self.regex = re.compile(r'^Element \'(?P<element>.+)\':( \[(?P<type>.+)\])? (?P<error>.*)$')
 
     def validate_data(self, data: Submission):
-        for entity_type, converter in CONVERSION_MAP:
+        for entity_type, converter in self.converter.conversion_map:
             ena_type = converter.ena_type.upper()
             entities = data.get_entities(entity_type)
             logging.info(f'Validating {len(entities)} {entity_type}(s) against ENA {ena_type} schema')
             for entity in entities:
                 schema = self.ena_schema[ena_type]
                 ena_set = etree.XML(f'<{ena_type}_SET />')
-                ena_set.append(EnaSubmissionConverter.convert_entity(converter, data, entity))
+                ena_set.append(self.converter.convert_entity(converter, data, entity))
 
                 if not schema(ena_set):
                     self.add_errors(schema, ena_type, entity_type, entity)


### PR DESCRIPTION
Generate Webin manifest files for experiment/runs.
Due to webin-cli's metadata requirements: Manifests are only generated if the experiment is linked to a study object with an  `ENA_Study` accession and a sample object with either a `BioSamples` or `ENA_Sample` accession.

~~To be useful in the "real-world" an additional feature is needed to allow the user to specify that the tool should submit the study object to ENA and the samples to BioSamples or ENA **without** sending the experiment/runs to ENA.
In this manner the tool could be used to generate all the pre-requisites for Webin-cli submissions.~~

The above feature is included, when using the `-webin-manifests` param only ENA Study and ENA Samples are generated by the ENA converter. ✅ 

